### PR TITLE
Delete member from project roles

### DIFF
--- a/backend/src/domain/Project.ts
+++ b/backend/src/domain/Project.ts
@@ -90,4 +90,8 @@ export interface ProjectRepository {
         user_id: string,
         roles: string[]
     ): Promise<boolean>;
+    RemoveUserFromProject(
+        project_id: string,
+        user_id: string
+    ): Promise<boolean>;
 }

--- a/backend/src/repo/MongoProjectRepository.ts
+++ b/backend/src/repo/MongoProjectRepository.ts
@@ -225,4 +225,24 @@ export class MongoProjectRepository implements ProjectRepository {
 
         return this.Update(project_id, { users: project.users });
     }
+
+    async RemoveUserFromProject(
+        project_id: string,
+        user_id: string
+    ): Promise<boolean> {
+        // Load project
+        const project = await this.GetById(project_id);
+        if(!project)
+            return false;
+
+        // Remove user from roles
+        for(const role of Object.keys(project.users)) {
+            // Do the actual removal
+        }
+
+        // Update UserRepository
+
+        // Delete when I have everything else
+        return false;
+    }
 }

--- a/backend/src/repo/MongoProjectRepository.ts
+++ b/backend/src/repo/MongoProjectRepository.ts
@@ -238,11 +238,16 @@ export class MongoProjectRepository implements ProjectRepository {
         // Remove user from roles
         for(const role of Object.keys(project.users)) {
             // Do the actual removal
+            project.users[role].users = project.users[role].users.filter(
+                (uid) => uid !== user_id
+            );
         }
 
-        // Update UserRepository
-
-        // Delete when I have everything else
-        return false;
+        // Apply update
+        const result = await this.collection.updateOne(
+            {  _id: new ObjectId(project_id) },
+            { $set: { users: project.users } }
+        );
+        return result.modifiedCount > 0;
     }
 }

--- a/backend/src/repo/StaticProjectRepository.ts
+++ b/backend/src/repo/StaticProjectRepository.ts
@@ -182,4 +182,6 @@ export class StaticProjectRepository implements ProjectRepository {
 
         return true;
     }
+
+    // TODO Copy over delete-member function from MongoProjectRepository when it's complete
 }

--- a/backend/src/repo/StaticProjectRepository.ts
+++ b/backend/src/repo/StaticProjectRepository.ts
@@ -184,4 +184,23 @@ export class StaticProjectRepository implements ProjectRepository {
     }
 
     // TODO Copy over delete-member function from MongoProjectRepository when it's complete
+    async RemoveUserFromProject(
+        project_id: string,
+        user_id: string
+    ): Promise<boolean> {
+        // Load project
+        const project = this._internal.find((p) => p._id === project_id);
+        if(!project)
+            return false;
+
+        // Remove user from roles
+        for(const role of Object.keys(project.users)) {
+            // Do the actual removal
+            project.users[role].users = project.users[role].users.filter(
+                (uid) => uid !== user_id
+            );
+        }
+
+        return true;
+    }
 }

--- a/backend/src/routers/ProjectRouter.ts
+++ b/backend/src/routers/ProjectRouter.ts
@@ -294,4 +294,51 @@ ProjectRouter.post('/api/projects', async (req: Request, res: Response) => {
     });
 });
 
+ProjectRouter.delete('/api/projects/:pid/members/:uid', async (req: Request, res: Response) => {
+    // Only allow if the member being removed is the logged in user,
+    // or if the logged in user is the project owner
+    if (!res.locals.user) {
+        res.status(401).json({
+            error: 'Unauthorized. You must be logged in to perform this action.',
+        });
+        return;
+    }
+
+    const { pid, uid } = req.params;
+    const db: Driver = req.app.locals.driver;
+
+    // Get project
+    const project = await db.projectRepository.GetById(pid);
+    if(!project) {
+        res.status(404).json({
+            error: 'Project not found.',
+        });
+        return;
+    }
+
+    // Case 1: Logged in user removing themselves from a project
+    // Case 2: Project owner removing another user
+    const isMe = uid === res.locals.user?._id;
+    const isOwner = project.owner === res.locals.user?._id;
+    if(!isMe && !isOwner) {
+        res.status(403).json({
+            error: 'Removal request denied.',
+        });
+    }
+
+    // Remove user from project's roles with new projectRepository function, passing pid and uid
+    // TODO Add when function is complete
+
+    // Remove project from user's projects
+
+    // Removal complete
+    /*
+    return res.status(200).json({
+        error: '',
+        result: 'Member removed successfully.'
+    });
+    */
+
+});
+
 export default ProjectRouter;

--- a/backend/src/routers/RequestRouter.ts
+++ b/backend/src/routers/RequestRouter.ts
@@ -228,6 +228,15 @@ RequestRouter.post(
             }
         }
 
+        const saveToProject = await db.projectRepository.Update(project_id, {
+            users: project.users,
+        });
+        if (!saveToProject) {
+            res.status(500).json({
+                error: 'Could not overwrite roles.',
+            });
+        }
+
         // // Place them into their assigned roles
         // for (let role of request.roles) {
         //     // make sure the role exists in the project and add it if it doesn't


### PR DESCRIPTION
New endpoint added to ProjectRouter, taking a project ID and a user ID (this user will be removed). The project's users and roles are update to exclude the user, and the user's projects list is updated as well. If you wish, I could add functionality for reversing a project's users/roles update if something goes wrong with updating the user itself.